### PR TITLE
Add Mac Storage Manager formula

### DIFF
--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -3,18 +3,18 @@ class Awscli < Formula
 
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
-  url "https://github.com/aws/aws-cli/archive/refs/tags/2.17.59.tar.gz"
-  sha256 "b9def6037a6dd579949eaae5da59083c6ecc27a7046f012263c41fa6837aabbf"
+  url "https://github.com/aws/aws-cli/archive/refs/tags/2.17.60.tar.gz"
+  sha256 "5b0b36665cbc8d8d1e27c449dfc09a5de3b9ccc2a66bef3b911770aa8dccb2fd"
   license "Apache-2.0"
   head "https://github.com/aws/aws-cli.git", branch: "v2"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "af530a040b009afb9ccfce85436660cf56d69ef45cffec2a84e765636f37d19f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5acd9beebeb4694a76aa27b13c2e76bc096b4bb261c0f93818367199e511d478"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "4eac3195c88e486874d93baea5e1ab6277c6fdb450fd44c782fa58f4501a573b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "de6082c09d321cc1c828093e09ac6767c5cc52a419f9c0339758d0be8e7f0c8a"
-    sha256 cellar: :any_skip_relocation, ventura:       "082f00f1daa809265348a134df43d9e2df01fb777c1cfd46ab0294198bac77e6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c288b5fb99e6f7775fec1cca6d8a46a6e3b19d34a19c4562d3c85b76bd150b22"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ff2c0dd19fb458951593dacb0aab77f1d08066714471dfd2780251da19b6dad9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6bd3383e43c85acfc404edf9c99e08210ea39547388ea02a5b837f6cfaf33c2b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "64ad9e0469dc4c6caecb427aa00d97e3ad14b66684dfce78456e5a789cae4457"
+    sha256 cellar: :any_skip_relocation, sonoma:        "487261584062271ae427325feed84a1c0cad358fa009d8c5a06782a632c038db"
+    sha256 cellar: :any_skip_relocation, ventura:       "a9eb969e61f367f9a3976ffd2933b9bd67aba5eff037a099caf70564a8e3f6ba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "10220ba7d8e82d5b496dafe951512bf19ed78d444bfafc71fa2c021b111bb37a"
   end
 
   depends_on "cmake" => :build

--- a/Formula/f/flyctl.rb
+++ b/Formula/f/flyctl.rb
@@ -2,8 +2,8 @@ class Flyctl < Formula
   desc "Command-line tools for fly.io services"
   homepage "https://fly.io"
   url "https://github.com/superfly/flyctl.git",
-      tag:      "v0.3.8",
-      revision: "db4d0d7641f87f0e9c1f46bd1728794e78f0f294"
+      tag:      "v0.3.10",
+      revision: "fb8153e0478281c49f278373fd8ee2001d2b5adb"
   license "Apache-2.0"
   head "https://github.com/superfly/flyctl.git", branch: "master"
 
@@ -18,12 +18,12 @@ class Flyctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "74906a2c5ccd2af0467cca50df2f0657db5d2424ee24c0c275488c02b9f3d9dc"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "74906a2c5ccd2af0467cca50df2f0657db5d2424ee24c0c275488c02b9f3d9dc"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "74906a2c5ccd2af0467cca50df2f0657db5d2424ee24c0c275488c02b9f3d9dc"
-    sha256 cellar: :any_skip_relocation, sonoma:        "592ed84b3047b9a6dacf44a3ab3e3707606453d8a36642833b3c7fc596c2222d"
-    sha256 cellar: :any_skip_relocation, ventura:       "592ed84b3047b9a6dacf44a3ab3e3707606453d8a36642833b3c7fc596c2222d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b5adcc6ee6a45c4d8551c8325406afcf091e2eddfeb7cd8db7632754d4c8303c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9d0162da027ca7748feabf8456a5adf2ad24d090678e6ed728c40996db1d1251"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9d0162da027ca7748feabf8456a5adf2ad24d090678e6ed728c40996db1d1251"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "9d0162da027ca7748feabf8456a5adf2ad24d090678e6ed728c40996db1d1251"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9fd41cf4fa50e66aef34cb005a449f9d2fbf61a870ee4a318c4e28f097842f2b"
+    sha256 cellar: :any_skip_relocation, ventura:       "9fd41cf4fa50e66aef34cb005a449f9d2fbf61a870ee4a318c4e28f097842f2b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b69721d24555ec49c4b1f0a6ceb549485a4f5c0ce71c222173c7e8783ea17bb8"
   end
 
   depends_on "go" => :build

--- a/Formula/f/fortio.rb
+++ b/Formula/f/fortio.rb
@@ -2,8 +2,8 @@ class Fortio < Formula
   desc "HTTP and gRPC load testing and visualization tool and server"
   homepage "https://fortio.org/"
   url "https://github.com/fortio/fortio.git",
-      tag:      "v1.66.5",
-      revision: "3af89dc91ec84b52b15015f771dc26d59e10416b"
+      tag:      "v1.67.0",
+      revision: "39daadd7c6dcce3ce3f990240fee9819c617d383"
   license "Apache-2.0"
 
   # There can be a notable gap between when a version is tagged and a
@@ -15,12 +15,12 @@ class Fortio < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7135bef976606a42c6bc0074bf022f1257e4fcd2453cd53c8c5995845ff1b632"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5974dff4b8e0ef64a8a1365525b5926411dee2a715f217ba50b6fc68db6ee85b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "e5c680ae26d9c42dc46bef031831f0c0257d4ebe6bcc9541e96b5dbf9fcf54c3"
-    sha256 cellar: :any_skip_relocation, sonoma:        "89a8fefb0091e6e170806a966769e63e307020c42beb2f60a4be3ebe64cbe8fa"
-    sha256 cellar: :any_skip_relocation, ventura:       "536141c09e85c704bd3d7f6e4849f4752e973be1665b4526c48eefd45ef05eec"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "40420e79b14fbc436ec542435d031daadc06e5f7825cbc46fe90ba2dc44bcda6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "31b658167c076ac7fa24dcfc3ed791b8529278d65fc8bb3f4e4509b71f9938a5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "39e715ba80e66baf5f89fd1beda5b72869441edf4d0a848bd1d060733e6f7dfe"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "ff28d502774fc05b01ec9f449ea0e9e947d62ed7dee0359975d344988d5e69d6"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d2a49f6cc3b97ed7366bdc64777c0a829be8289d3d00bc73fa67ecdc1a87b8b1"
+    sha256 cellar: :any_skip_relocation, ventura:       "b3affc3b4e8c42fd79e447205da472e41b1503e561ae91d55e9268ef0144dd1c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4cfa0c6470dc4a4fd3412a1a2dfbb1db5141bdf5cc18dc1892c0f983578e2e60"
   end
 
   depends_on "go" => :build

--- a/Formula/m/mdcat.rb
+++ b/Formula/m/mdcat.rb
@@ -1,18 +1,18 @@
 class Mdcat < Formula
   desc "Show markdown documents on text terminals"
   homepage "https://github.com/swsnr/mdcat"
-  url "https://github.com/swsnr/mdcat/archive/refs/tags/mdcat-2.4.0.tar.gz"
-  sha256 "1789347b35abff00e04f8941c6970a7ab8ae6ad0a0ec7a33fe3ef39021a7b17f"
+  url "https://github.com/swsnr/mdcat/archive/refs/tags/mdcat-2.5.0.tar.gz"
+  sha256 "fc7855277a2f5e0c9ca74f9a9f72c8f527dde8ae16d2aa9bbe6a249040592aea"
   license "MPL-2.0"
   head "https://github.com/swsnr/mdcat.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "47072257cbcf508e022b601ee6524ab173b6df352232366fed7865937d40a8c3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b39f389a754f88656051608e39566bf9bd47fafe07c4c8025d7bb402d51f2c79"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "213cdf57a3bffd9bdf71d4313956ab09f81da4838f7d23d05e3992cd9f016f93"
-    sha256 cellar: :any_skip_relocation, sonoma:        "213fb271d01940fe3bc4f402f13e5378b41a79a0e606262c3a87eed84fbe2df2"
-    sha256 cellar: :any_skip_relocation, ventura:       "1f224972cbe411a80064f62c611f1077fc3644477196bb94569647382fecae32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "81c41147f470d6ecc0f1d27807470621d60011f1e3e9b3939929178691c14e41"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e091e8f07d47fb1fa69efae631c459a9e3f793ba8efee226a01f5de4201f80e6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ed13411f7ccee13439c01c33afa8be8f98746dc204744bda9dc55d1fc8fdb404"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "597aa7f1d640efb41bf3c9fad7b1869a2c91237a29fc712dbbbad2e9de71b9dc"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9b282b41eea98066429f5bd4b19418ed0281fabc258292801199f45ba4b2a835"
+    sha256 cellar: :any_skip_relocation, ventura:       "7757a1701707005ddabb6c8ee4fbe76641396029a6a8677eec1b7dd37d1939c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "24dfd12efa1d77060747414c2c03796a11e6aa47489ba6af81a5b80848757d40"
   end
 
   depends_on "asciidoctor" => :build

--- a/Formula/m/mise.rb
+++ b/Formula/m/mise.rb
@@ -1,8 +1,8 @@
 class Mise < Formula
   desc "Polyglot runtime manager (asdf rust clone)"
   homepage "https://mise.jdx.dev/"
-  url "https://github.com/jdx/mise/archive/refs/tags/v2024.9.9.tar.gz"
-  sha256 "fc368d904d92b83342032734d6548093973af7b8c5f9035473548cd745bcbff3"
+  url "https://github.com/jdx/mise/archive/refs/tags/v2024.9.10.tar.gz"
+  sha256 "ee2ef8092884c66840bc4fe0af1dfbe1a71bfad3e6278cad307ac0d6d03e35cc"
   license "MIT"
   head "https://github.com/jdx/mise.git", branch: "main"
 
@@ -12,12 +12,12 @@ class Mise < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "6e9b1faf6569a37ccf437ff41b33524d3e2e3c4bee3bf4c4bb9299c187459b91"
-    sha256 cellar: :any,                 arm64_sonoma:  "03460417079af7305076437f067854e48232fe93f31dc1f4fccbbaed4a2f5d17"
-    sha256 cellar: :any,                 arm64_ventura: "8ab5e4286905d2c4bab71352683b81177dab26bbb233f9e4f2321aad68d6e714"
-    sha256 cellar: :any,                 sonoma:        "b9e645ac0867f1bddae3372232305245c2f98b7888a24f391f9ccfdb16edb4a0"
-    sha256 cellar: :any,                 ventura:       "c036f41ad28e03cc894c570e60fb7bf291ff8f8bf76f75b8b32e53580178886c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e642672d9e5940173bd6d5470711b344a60815384707802c1626fc4cbec3ca7f"
+    sha256 cellar: :any,                 arm64_sequoia: "72b5843d322714f3c5541fc1947f65360199ad9f29078ab5872f0b6bb4cbfe6f"
+    sha256 cellar: :any,                 arm64_sonoma:  "032d02f7b9455e5fc5c281aa27c5e497fca2dbb171bd36c6fdfddb4f53ba71a4"
+    sha256 cellar: :any,                 arm64_ventura: "e5d6f7145864616257918c7789991dfe3e8eca97dfe5f1ac57892c0c6de6ad40"
+    sha256 cellar: :any,                 sonoma:        "d82a253b6b5e83e927540e993cb3dafeb663378089438261bb9af2025dc5ab81"
+    sha256 cellar: :any,                 ventura:       "f70ffef6825d6eaee3d485da3fe2596fd2324ac1cd101737dc63a1d659be2948"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "87a2d7355bc163dbb81224dfedefdc018209ab1ee2e0c4d5e4183959066f7c6a"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/o/onedrive.rb
+++ b/Formula/o/onedrive.rb
@@ -1,12 +1,12 @@
 class Onedrive < Formula
   desc "Folder synchronization with OneDrive"
   homepage "https://github.com/abraunegg/onedrive"
-  url "https://github.com/abraunegg/onedrive/archive/refs/tags/v2.5.0.tar.gz"
-  sha256 "6ddf92bf564e71871d1d49e4120f0848f79bc3e55155a73c2b882752fa13a431"
+  url "https://github.com/abraunegg/onedrive/archive/refs/tags/v2.5.1.tar.gz"
+  sha256 "99c1ad66fe9f595b84e9de397767f8337066f911a0ad90371855d7fa906d3d31"
   license "GPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5ef60eba305591ad6d90aab590004ef1ae734a71916cce7ebff83e1ae42ab299"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "9118476e4d5c2459271abf201611e917736a39afbaa6207a9a58ad320648684c"
   end
 
   depends_on "ldc" => :build

--- a/Formula/r/railway.rb
+++ b/Formula/r/railway.rb
@@ -1,18 +1,18 @@
 class Railway < Formula
   desc "Develop and deploy code with zero configuration"
   homepage "https://railway.app/"
-  url "https://github.com/railwayapp/cli/archive/refs/tags/v3.14.1.tar.gz"
-  sha256 "990fa647d842943bee7fe5694d2c553bc10e9de51cf0421a3ea682c1194b6a22"
+  url "https://github.com/railwayapp/cli/archive/refs/tags/v3.15.1.tar.gz"
+  sha256 "f3f610be6377a9b8554940ddaf922dbd01235936900724c2930b937f84e1c417"
   license "MIT"
   head "https://github.com/railwayapp/cli.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "56bd1cb1c6026dee4d61a388f9c90e65d4f55edeeb4c8e3aa863211ba6c5ff0e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "78afc74a7034d6849ee7b1e12dc4547695b979f9fc127830b20c8a16be537378"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "02fe477aa5f9bb4343e67306db0a01a05ddb81cd95dd22800ccf71008cfc3061"
-    sha256 cellar: :any_skip_relocation, sonoma:        "45662540a3757b2765fb140775b7bdd2eaa4005f20bfeba526e7b6d78812ba89"
-    sha256 cellar: :any_skip_relocation, ventura:       "81de42dbbf70f36e19f799be47a4e99ecc018a64118c4fa58062d2c6f8b6e578"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7fe5f7bb68c42b8f9a5c9deb355815d98e6f657a7c77f35fcc9dabd7b5f30263"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6d073fadd55af4d911fa8dac8a15ed77aabb307f87bf58e35a9ac2b63076661f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "de47f9d1d285e492c857ca17bda8b6164e50d1d0069af6e61752b67ca7fd34ff"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "3e8f086bffca618efc657b71d281cb450b52a83a723a3e9795fe7024fb6486da"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c071654ae3895ce808601ab9d9613b5b0f0fc3200fdb5c7623a78082800ce18e"
+    sha256 cellar: :any_skip_relocation, ventura:       "33fd67e9b5cd33adafb9096d8d3e10182c51990b301b438297d51289d53caa45"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "505523d63ad92debf5b12e636257156f6dc1802fe7a151bafe67f3c2f1d98429"
   end
 
   depends_on "rust" => :build

--- a/Formula/s/silk.rb
+++ b/Formula/s/silk.rb
@@ -1,8 +1,8 @@
 class Silk < Formula
   desc "Collection of traffic analysis tools"
   homepage "https://tools.netsa.cert.org/silk/"
-  url "https://tools.netsa.cert.org/releases/silk-3.23.0.tar.gz"
-  sha256 "cf83eb0960ba25e0855c4c45f86fe371ecc5f3f755790203f434a84f871065cf"
+  url "https://tools.netsa.cert.org/releases/silk-3.23.1.tar.gz"
+  sha256 "c3277352764fa9167a6130739bd4b7cc8ebcb7b7d4f727b46facd7b135f26c23"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   livecheck do
@@ -11,14 +11,12 @@ class Silk < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia:  "324aacc439257c4679841ffedf2c0e8282a5b7bf45020c734bc15fad9869b904"
-    sha256 arm64_sonoma:   "f12e6a010a351424c14ea5b4f7d22c23bdb12e6b0da9d07259219c7f27fba4f4"
-    sha256 arm64_ventura:  "912070ff680bb0dd6996a42c132d5e7148875c0983345eeaa8698d969669e3c9"
-    sha256 arm64_monterey: "3fe1b2927abfedce7920056f3f555b2c6878db91bb1edabc8226e2fa1de6d4d1"
-    sha256 sonoma:         "1b5e0a040b20cc35637472dcd3a9fb513f87d4842ae1985224312dc627474cad"
-    sha256 ventura:        "48d18f78bf1ea1b776348af588b80886795ba1a9bab7748209d5d67c2ce8e5c5"
-    sha256 monterey:       "da008f1f90a12c2d99c95384e62424274b5d4f8f9a063dd3abfb9eb3bf92b9b2"
-    sha256 x86_64_linux:   "4097d62607a2c7620854b51a4dedfec4cf8b586e4281adc27742369cc60b0814"
+    sha256 arm64_sequoia: "9174f223744ea5a48b59a4ab66269bb36e0033cbd9925a248120708b33522eb0"
+    sha256 arm64_sonoma:  "df1f4e0f33fcf049b18992fb1a84323c9891339dd66bc6f9ea0d18405e97c6da"
+    sha256 arm64_ventura: "676fbf5554b1e229f629728f296ea6fa5f99080bf27745ce7af7f95c24f0a441"
+    sha256 sonoma:        "37d538756d940202a4319f73ce6d67011091bebd12aabeeecd3900edf854d9ba"
+    sha256 ventura:       "e3200fa12fbbe0cad5b28db61d65e73269abb80ab21396e1607783d0caf432e1"
+    sha256 x86_64_linux:  "41438d609da5625f2a222397a1e8e5e85c82d2fe5aed69192e5b82394f52ebc0"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
This PR adds a formula for Mac Storage Manager, a tool designed to help manage disk space on macOS by calculating the sizes of installed applications and Homebrew packages.

**Key Features:**
- Calculates sizes for Homebrew formulas, casks, and applications in `/Applications` and `~/Applications`.
- Allows for interactive deletion of applications, with an option to remove related caches.
- Includes progress bar and sound feedback to improve user interaction.

**Dependencies:**
- `jq` for JSON processing.
- `parallel` for efficient parallel execution of tasks.
- `newt` for text-based user interface support.

The tool provides a convenient way for macOS users to monitor and manage disk space usage by installed applications.
